### PR TITLE
Ability to write output as json

### DIFF
--- a/src/log/formatters/__init__.py
+++ b/src/log/formatters/__init__.py
@@ -1,0 +1,1 @@
+from .json_formatter import JsonFormatter

--- a/src/log/formatters/json_formatter.py
+++ b/src/log/formatters/json_formatter.py
@@ -1,0 +1,26 @@
+import logging
+import json
+from datetime import datetime
+
+
+class JsonFormatter(logging.Formatter):
+
+    def format(self, record: logging.LogRecord) -> str:
+        """formats the log record as a json object
+
+        Parameters
+        ----------
+        record : loggig.LogRecord
+            message to be sent to the logger
+
+        Returns
+        -------
+        str
+            returns the formatted json object as a string
+        """
+        formatted_log = {
+            "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+            "loglevel": record.levelname,
+            "logger_name": record.name,
+        }
+        return json.dumps(formatted_log)

--- a/src/log/formatters/json_formatter.py
+++ b/src/log/formatters/json_formatter.py
@@ -1,9 +1,14 @@
 import logging
 import json
-from datetime import datetime
 
 
 class JsonFormatter(logging.Formatter):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._record_keys = logging.LogRecord(
+            "", 0, "", 0, "", (), None
+        ).__dict__.keys()
 
     def format(self, record: logging.LogRecord) -> str:
         """formats the log record as a json object
@@ -19,8 +24,23 @@ class JsonFormatter(logging.Formatter):
             returns the formatted json object as a string
         """
         formatted_log = {
-            "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+            "timestamp": record.asctime,
             "loglevel": record.levelname,
             "logger_name": record.name,
+            "filepath": record.pathname,
+            "function_call": record.funcName,
+            "line_number": record.lineno,
+            "message": record.getMessage(),
+            "context": {},  # This value is purely going to hold additional context for the program
+            "exception": "",
         }
+
+        # Add key values for context if an LoggerAdapter was used.
+        for key, value in record.__dict__.items():
+            if key not in self._record_keys:
+                formatted_log["context"][key] = value
+
+        if record.exc_info:
+            formatted_log["exception"] = self.formatException(record.exc_info)
+
         return json.dumps(formatted_log)


### PR DESCRIPTION
Sometimes having structured logging in the output log file is more beneficial than having a formatted string. This module contains a custom logger for JSON. The json object records a lot of the runtime information and can include additional context if it is passed through a LoggerAdapter. I added a parameter to the FormatterOpts class called "write_json" that would allow the user to switch between the JsonFormatter and the normal logging.FileFormattter. This commit will be a part of finishing issue #5.